### PR TITLE
2018 112M taxi trips dataset filtering and 5 new APIs

### DIFF
--- a/assignment2/app.py
+++ b/assignment2/app.py
@@ -330,6 +330,65 @@ def payment_trend_timeline_2018():
   return jsonify(trends)
 
 
+@app.route('/interval-tree-passengers', methods=['GET'])
+def interval_tree_passengers():
+  """
+  Interval tree data. X: year-month period of taxi sample data, Y: passenger number.
+  {
+    "YAxisMax": 8,
+    "data": [
+      {"fromDate": "2018-12", "passengerNum": 0, "toDate": "2018-12"},
+      {...},
+      ...
+    ]
+  }
+  """
+  query = ''' SELECT passenger_count, 
+        STRFTIME('%Y-%m',MIN(tpep_pickup_datetime)) AS from_dt, 
+        STRFTIME('%Y-%m',MAX(tpep_pickup_datetime)) AS to_dt 
+        FROM trips
+        GROUP BY passenger_count
+        ORDER BY passenger_count; '''
+  data_result = execute_query(query)
+  query = ''' SELECT MAX(passenger_count) FROM trips; '''
+  y_axis_max = execute_query(query)[0][0]
+  return jsonify(
+    {
+      'YAxisMax' : y_axis_max,
+      'data' : [{'passengerNum': a[0],
+                'fromDate': a[1], 
+                'toDate': a[2]} for a in data_result]
+    }
+  )
+
+
+@app.route('/interval-tree-passengers-2018', methods=['GET'])
+def interval_tree_passengers_2018():
+  """
+  Interval tree data. X: month period of 2018, Y: passenger number.
+  {
+    "YAxisMax": 192,
+    "data": [
+      {"fromDate": 1, "passengerNum": 0, "toDate": 12},
+      {...},
+      ...
+    ]
+  }
+  """
+  query = ''' SELECT * FROM temp_interval_tree_passengers_2018; '''
+  data_result = execute_query(query)
+  query = ''' SELECT MAX(passenger_count) FROM temp_interval_tree_passengers_2018; '''
+  y_axis_max = execute_query(query)[0][0]
+  return jsonify(
+    {
+      'YAxisMax' : y_axis_max,
+      'data' : [{'passengerNum': a[0],
+                'fromDate': int(a[1]), 
+                'toDate': int(a[2])} for a in data_result]
+    }
+  )
+
+
 if __name__ == '__main__':
   app.debug = True
   app.teardown_appcontext(close_db)

--- a/assignment2/setup_db.py
+++ b/assignment2/setup_db.py
@@ -358,6 +358,17 @@ def create_temp_data():
         GROUP BY month, payment_type
         ORDER BY month, payment_type;
     ''')
+    # /payment-trend-timeline
+    print('creating /interval-tree-passengers-2018 temp table')
+    c.execute('''
+    CREATE TABLE temp_interval_tree_passengers_2018 AS
+        SELECT passenger_count, 
+        STRFTIME('%m',MIN(tpep_pickup_datetime)) AS from_dt, 
+        STRFTIME('%m',MAX(tpep_pickup_datetime)) AS to_dt 
+        FROM trips_non_sample
+        GROUP BY passenger_count
+        ORDER BY passenger_count;
+    ''')
     conn.commit()
     conn.close()
 
@@ -366,7 +377,9 @@ def drop_2018_taxi_data():
     # connect db
     conn = sqlite3.connect('assignment2.db')
     c = conn.cursor()
+    print('dropping 2018 112M data from database')
     c.execute(''' DROP TABLE IF EXISTS trips_non_sample; ''')
+    print('executing sqlite vacuum;')
     c.execute(''' vacuum; ''') # shrink db file
     conn.commit()
     conn.close()
@@ -376,5 +389,5 @@ if __name__ == '__main__':
     # setup_database()
     # setup_2018_taxi()
     # filter_2018_trips()
-    # create_temp_data()
+    create_temp_data()
     drop_2018_taxi_data()

--- a/assignment2/setup_db.py
+++ b/assignment2/setup_db.py
@@ -386,8 +386,8 @@ def drop_2018_taxi_data():
 
     
 if __name__ == '__main__':
-    # setup_database()
-    # setup_2018_taxi()
-    # filter_2018_trips()
+    setup_database()
+    setup_2018_taxi()
+    filter_2018_trips()
     create_temp_data()
     drop_2018_taxi_data()

--- a/assignment2/setup_db.py
+++ b/assignment2/setup_db.py
@@ -368,6 +368,7 @@ def drop_2018_taxi_data():
     conn = sqlite3.connect('assignment2.db')
     c = conn.cursor()
     c.execute(''' DROP TABLE IF EXISTS trips_non_sample; ''')
+    c.execute(''' vacuum; ''') # shrink db file
     conn.commit()
     conn.close()
 

--- a/assignment2/setup_db.py
+++ b/assignment2/setup_db.py
@@ -1,5 +1,4 @@
 import sqlite3, csv
-import pandas as pd
 
 from datetime import datetime
 from zipfile import ZipFile


### PR DESCRIPTION
This pull request contains 1)stream storing 112M dataset, filtering dataset, creating temporary/cached tables for new APIs and removing dataset. 2) new 5 APIs:
 - `/average-passenger-counts-2018`
 - `/pickup-rush-hours-2018`
 - `/busy-areas-2018`
 - `/payment-trend-usage-2018`
 - `/payment-trend-timeline-2018`

The structures and functions are same as old APIs' except for the last one where I changed the `date` to `month` as Soroush has requested. 

To save time (this script will take roughly 5+ hours to run), the database file that is processed by myself using the script can be downloaded here: 
https://drive.google.com/open?id=1POc_uU6bnQKImJsnsS5QQrdPVk5x01X0

Here are the tasks what I have done:
1. I downloaded and stream stored it to a local sqlite database
2. I then applied two filters to the original data: 1) exclude trip data with pickup/dropoff datetime outside of 2018 timeframe. 2) remove duplicate data. This step dropped 9,433,333 trip data.
3. I tried querying data for `/payment-trend-timeline`, and the api responded after 15 minutes, I thought this is taking way too long and decided to move on to create temporary/cached tables for 5 APIs. After this step, the query time for each API is <1 sec.
4. In order to make our database sharable for team members, I removed the 112M 2018 taxi trips data from the database and only keep 5 temp/cached tables for API queries. The size of the db file now is dropped from 11.8GB to  110MB.